### PR TITLE
Build Tesseract with libarchive-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: graphics
 Priority: optional
 Maintainer: Alexander Pozdnyakov <almipo@mail.ru>
 Build-Depends: debhelper (>= 9), libleptonica-dev (>= 1.75.3),
-               automake, libtool, libpango1.0-dev, libcairo2-dev, libicu-dev,
+               automake, libtool, libarchive-dev, libpango1.0-dev, libcairo2-dev, libicu-dev,
                libpng-dev, libjpeg-dev, libtiff-dev, zlib1g-dev, git, autoconf-archive, asciidoc,
                xsltproc, docbook-xsl, docbook-xml, tesseract-ocr-eng (>= 4.00~)
 Standards-Version: 4.3.0

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Alexander Pozdnyakov <almipo@mail.ru>
 Build-Depends: debhelper (>= 9), libleptonica-dev (>= 1.75.3),
                automake, libtool, libarchive-dev, libpango1.0-dev, libcairo2-dev, libicu-dev,
-               libpng-dev, libjpeg-dev, libtiff-dev, zlib1g-dev, git, autoconf-archive, asciidoc,
+               libpng-dev, libjpeg-dev, libtiff-dev, zlib1g-dev, git, asciidoc,
                xsltproc, docbook-xsl, docbook-xml, tesseract-ocr-eng (>= 4.00~)
 Standards-Version: 4.3.0
 Homepage: https://github.com/tesseract-ocr/


### PR DESCRIPTION
Starting with 4.1.0, Tesseract can read traineddata which was
packed in any of the formats which are supported by libarchive.

This requires libarchive-dev for the build.

Remove also an unneeded dependency on autoconf-archive.

Signed-off-by: Stefan Weil <sw@weilnetz.de>