### PR TITLE
Revert "Revert "Build does not need autoconf-archive""

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Alexander Pozdnyakov <almipo@mail.ru>
 Build-Depends: debhelper (>= 9), libleptonica-dev (>= 1.75.3),
                automake, libtool, libarchive-dev, libpango1.0-dev, libcairo2-dev, libicu-dev,
-               libpng-dev, libjpeg-dev, libtiff-dev, zlib1g-dev, git, autoconf-archive, asciidoc,
+               libpng-dev, libjpeg-dev, libtiff-dev, zlib1g-dev, git, asciidoc,
                xsltproc, docbook-xsl, docbook-xml, tesseract-ocr-eng (>= 4.00~)
 Standards-Version: 4.4.1
 Homepage: https://github.com/tesseract-ocr/


### PR DESCRIPTION
This reverts commit 29160ac991ca19159b22327c0abfaf3ee03f64ea.

Bug #949119 wrongly reported a dependency on autoconf-archive
which is not needed.

Signed-off-by: Stefan Weil <sw@weilnetz.de>