### PR TITLE
Update URLs for documentation

### DIFF
--- a/debian/README.debian
+++ b/debian/README.debian
@@ -1,11 +1,11 @@
 Upstream user documentation:
 
-   https://github.com/tesseract-ocr/tesseract/wiki
+   https://tesseract-ocr.github.io/
 
 Auto generated API documentation:
 
-   http://tesseract-ocr.github.io/4.x/
+   http://tesseract-ocr.github.io/tessapi/5.x/
 
 Training documentation:
 
-   https://github.com/tesseract-ocr/tesseract/wiki/TrainingTesseract-4.00
+   https://tesseract-ocr.github.io/tessdoc/tess4/TrainingTesseract-4.00

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -2,7 +2,7 @@ Name: tesseract-ocr
 Homepage: https://github.com/tesseract-ocr/
 Bug-Database: https://github.com/tesseract-ocr/tesseract/issues
 Changelog: https://github.com/tesseract-ocr/tesseract/releases
-FAQ: https://github.com/tesseract-ocr/tesseract/wiki/FAQ
+FAQ: https://tesseract-ocr.github.io/tessdoc/FAQ
 Contact: http://groups.google.com/group/tesseract-ocr
 Repository: https://github.com/tesseract-ocr/tesseract.git
 Repository-Browse: https://github.com/tesseract-ocr/tesseract


### PR DESCRIPTION
The Tesseract wiki no longer contains the documentation.

Signed-off-by: Stefan Weil <sw@weilnetz.de>